### PR TITLE
Upgrade the-last-browser-launcher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,23 @@ language: node_js
 
 os:
   - linux
-  # TODO: firefox doesn't close
-  # - osx
-  # TODO: where does travis install chrome and ff? they can't be found
-  # - windows
+  - osx
+  - windows
+
+cache:
+  npm: false
 
 node_js:
   - 10
   - 12
   - 14
 
+before_install:
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then choco install googlechrome -y --ignore-checksums; fi
+
 addons:
   chrome: stable
   firefox: latest
-
-services:
-  - xvfb
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # airtap-system
 
-**[Browser provider](https://github.com/airtap/browser-provider) for locally installed browsers. List and run browsers on your machine. Supports Chrome, Chromium, Firefox, IE, Edge, Brave, Opera and Safari.**
+**[Browser provider](https://github.com/airtap/browser-provider) for locally installed browsers. List and run browsers on your machine. Supports Chrome, Chromium, Firefox, IE, Edge, Brave, Opera and Safari, on Linux, Mac & Windows, with cross-platform headless mode on Chromium, Chrome, Edge, Brave and Firefox.**
 
 [![npm status](http://img.shields.io/npm/v/airtap-system.svg)](https://www.npmjs.org/package/airtap-system)
 [![node](https://img.shields.io/node/v/airtap-system.svg)](https://www.npmjs.org/package/airtap-system)
@@ -50,8 +50,7 @@ providers:
 browsers:
   - name: firefox
     version: 79
-  - name: firefox
-    version: dev
+  - name: chrome
 ```
 
 This provider also exposes a [`supports`](https://github.com/airtap/browser-manifest#supports) property to match on:
@@ -63,6 +62,18 @@ browsers:
       headless: true
 ```
 
+As well as a release `channel` and (Windows-only) `arch`:
+
+```yaml
+browsers:
+  - name: chrome
+    channel: beta
+  - name: firefox
+    channel: nightly
+  - name: ie
+    arch: i386
+```
+
 ## API
 
 ### `System()`
@@ -71,7 +82,7 @@ Constructor. Returns an instance of [`browser-provider`](https://github.com/airt
 
 ### Browser options
 
-- `headless` (boolean, default true): run in headless mode (Linux and Mac only, requires `xvfb` to be preinstalled).
+- `headless` (boolean, default true if supported): run in headless mode.
 
 In Airtap these can be set like so:
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "browser-provider": "^1.1.0",
     "debug": "^4.1.1",
     "tasklist": "^4.0.1",
-    "the-last-browser-launcher": "0.0.1",
-    "which": "^2.0.2"
+    "the-last-browser-launcher": "^0.1.0"
   },
   "devDependencies": {
     "airtap": "^4.0.1",


### PR DESCRIPTION
Comes with:

- Cross-platform headless mode on Chromium, Chrome, Edge, Brave and Firefox.
- New manifest properties like `channel`, which enables matching by release channel, for example to select Firefox Nightly.
- Fixes for Firefox & Safari on Mac